### PR TITLE
fix: sign libsqlitejdbc.jnilib for mac x64

### DIFF
--- a/.changeset/rude-scissors-visit.md
+++ b/.changeset/rude-scissors-visit.md
@@ -1,0 +1,5 @@
+---
+'@krud-dev/boost': patch
+---
+
+Added signature for x64 native sqlite library for mac


### PR DESCRIPTION
Following the fix offered here:

https://github.com/xerial/sqlite-jdbc/issues/383

Previously we mistakenly only did it for arm.

Closes #379 