### PR TITLE
fix: limit amount of instances to check when checking application abilities

### DIFF
--- a/.changeset/perfect-eyes-protect.md
+++ b/.changeset/perfect-eyes-protect.md
@@ -1,0 +1,5 @@
+---
+"@krud-dev/ostara-main": patch
+---
+
+Added limit to the amount of instances being fetched when checking application abilities


### PR DESCRIPTION
Closes #581